### PR TITLE
Fix queue issue in handle_message()

### DIFF
--- a/test/hot_loader/asset_change_set_test.rb
+++ b/test/hot_loader/asset_change_set_test.rb
@@ -6,7 +6,8 @@ TEST_ASSET_1 = %|var testAsset1 = function () {
     null,
     "test asset 1"
   );
-};|
+};
+|
 
 describe React::Rails::HotLoader::AssetChangeSet do
   it 'notes files that changed' do

--- a/test/hot_loader/server_test.rb
+++ b/test/hot_loader/server_test.rb
@@ -20,6 +20,20 @@ describe React::Rails::HotLoader::Server do
     assert_equal [expected_content], changed_contents
   end
 
+  it 'dont process more than once msg with the same timestamp' do
+    timestamp = Time.now.to_i.to_s
+
+    touch_asset("test_asset_1.js.jsx")
+    @client.send(timestamp)
+    until @client.received.length > 0; end
+    assert_equal 1, @client.received.length
+
+    @client.send(timestamp)
+    until @client.received.length > 0; end
+    sleep 1
+    assert_equal 1, @client.received.length
+  end
+
   describe "when too many files changed" do
     before do
       React::Rails::HotLoader::AssetChangeSet.bankruptcy_count = 2


### PR DESCRIPTION
In a case when processing request on server side take longer that default interval (1500ms), calls with the same timestamp are queued and processed couple times. In effect, a new change is sent to client several times.  
This fixes this issue by storing history latest processed client timestamp and skip already done. 