### PR TITLE
Rails 5 Reloader Support

### DIFF
--- a/lib/hot_loader/railtie.rb
+++ b/lib/hot_loader/railtie.rb
@@ -11,7 +11,13 @@ module React
           if ::Rails.env.development?
             React::Rails::HotLoader.restart
 
-            ActionDispatch::Reloader.to_prepare do
+            rails_reloader_klass = if defined?(ActiveSupport::Reloader)
+                                     ActiveSupport::Reloader
+                                   else # All other versions
+                                     ActionDispatch::Reloader
+                                   end
+
+            rails_reloader_klass.to_prepare do
               # Seems like Passenger kills threads on the main process
               # In that case, `starting_worker_process` isn't good enough
               # because it doesn't run :(


### PR DESCRIPTION
I just created a new Rails 5.1.1 project and added the React Rails Hot Loader and the project wouldn't start. Tracked it back to `ActionDispatch::Reloader` being deprecated in favor of `ActiveSupport::Reloader`. This patch adds support for either version. 

Active Admin ran into the same issue and was discussed here:
https://github.com/activeadmin/activeadmin/issues/4438